### PR TITLE
Fix: infinite call loadMore when height changes but not enough

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -172,6 +172,10 @@ var doCheck = function (force) {
 
     shouldTrigger = viewportBottom + distance >= elementBottom;
   }
+  
+  // If triggered last time, then ignore this as there is no enough height growth
+  if(this.shouldTrigger === shouldTrigger) return;
+  this.shouldTrigger = shouldTrigger;
 
   if (shouldTrigger && this.expression) {
     this.expression();


### PR DESCRIPTION
修复以下情况下会导致无限调用 loadMore 的情况：
1. 当调用 loadMore，产生新的高度变化，但是这个高度不够 infinite-scroll-distance 时，导致再次调用 loadMore
2. 当调用 loadMore 时，由于底部有加载动作条渲染，而实际上又没有新的数据（比如接口返回零行），导致无限调用 loadMore

会产生一个副作用：如果在某一时刻，整个 element 的滚动条可滚动区域都不足 infinite-scroll-distance，将不会再产生新的事件了（即不会再调用 loadMore 了）。其实这跟没有滚动条的情况是一样的，都需要用户自己去处理（比如在底部加一个"点击加载更多”状态条）